### PR TITLE
Use peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "main": "dist/vuetable-3.umd.js",
   "peerDependencies": {
-    "axios": "^1.6.0",
+    "axios": "^1.7.4",
     "vuedraggable-es": "^4.1.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "test": "jest"
   },
   "main": "dist/vuetable-3.umd.js",
-  "dependencies": {
-    "axios": "1.6.0",
+  "peerDependencies": {
+    "axios": "^1.6.0",
     "vuedraggable-es": "^4.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Currently axios has a fixed version in the `package.json`, this version throws an ˙npm audit` warning.  

```
# npm audit report

axios  1.3.2 - 1.7.3
Severity: high
Server-Side Request Forgery in axios - https://github.com/advisories/GHSA-8hc4-vh64-cxmj
fix available via `npm audit fix`
node_modules/@dcodegroup-au/vuetable-3/node_modules/axios
  @dcodegroup-au/vuetable-3  >=6.1.4
  Depends on vulnerable versions of axios
  node_modules/@dcodegroup-au/vuetable-3

2 high severity vulnerabilities
```

If we use `peerDependencies ` we upgrade the `axios` package.