### PR TITLE
Update sort on setData

### DIFF
--- a/src/components/Vuetable.vue
+++ b/src/components/Vuetable.vue
@@ -710,12 +710,14 @@ export default {
 
       if (Array.isArray(data)) {
         this.tableData = data;
+        this.sortOrderData = this.sortOrder;
         this.fireEvent("loaded");
         this.loading = false
         return;
       }
 
       this.tableData = this.getObjectValue(data, this.dataPath, null);
+      this.sortOrderData = this.sortOrder;
       this.tablePagination = this.getObjectValue(
         data,
         this.paginationPath,


### PR DESCRIPTION
If you delete a row from the table on the first page, the `sortOrderData` changes are not tracked anymore. This causes the sorting buttons to do nothing.

The PR overrides the `sortOrderData` with the `tableData` and `tablePagination` and according to my tests, it now works.