### PR TITLE
🚨 SECURITY: Pin axios to 1.13.6 (supply chain attack)

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,5 +151,8 @@
   "directories": {
     "doc": "docs",
     "test": "tests"
+  },
+  "overrides": {
+    "axios": "1.13.6"
   }
 }


### PR DESCRIPTION
## axios supply chain attack — March 31 2026

Malicious versions `axios@1.14.1` and `axios@0.30.4` were published via compromised maintainer credentials. They inject `plain-crypto-js@4.2.1` which drops a cross-platform RAT.

### Changes
- Pins axios to `1.13.6` (last safe release)
- Adds `overrides` to block transitive resolution to compromised versions
- Regenerates lockfile

### Action required
If any machine has already installed the compromised version, treat it as compromised:
- Rotate all secrets/credentials
- Check for C2 connections to `sfrclak.com` / `142.11.206.73`
- Look for: `/Library/Caches/com.apple.act.mond` (mac), `%PROGRAMDATA%\wt.exe` (win), `/tmp/ld.py` (linux)

### References
- https://www.stepsecurity.io/blog/axios-compromised-on-npm-malicious-versions-drop-remote-access-trojan
- https://news.ycombinator.com/item?id=47581837